### PR TITLE
README: Don't boost when kprofiles is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ long _do_fork(unsigned long clone_flags,
 +    * Dont boost CPU & DDR if battery saver profile is enabled
 +    * and boost CPU & DDR for 25ms if balanced profile is enabled
 +    */
-+       if (kp_active_mode() == 3 || kp_active_mode() == 0) {
++       if (kp_active_mode() == 3) {
 +           cpu_input_boost_kick_max(50);
 +           devfreq_boost_kick_max(DEVFREQ_MSM_LLCCBW, 50);
 +           devfreq_boost_kick_max(DEVFREQ_MSM_CPUBW, 50);


### PR DESCRIPTION
*Boosting the CPU and DDR when kprofiles is disabled doesn't make sense

Signed-off-by: Forenche <prahul2003@gmail.com>