### PR TITLE
kp: Add auto kprofiles support for MI DRM Notifier

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -44,6 +44,16 @@ config AUTO_KPROFILES_MSM_DRM
 	  mode when device screen turns off and will switch back to previously active
 	  mode when the device wakes up.
 
+config AUTO_KPROFILES_MI_DRM
+	bool "Auto Kprofiles using mi_drm_notifier"
+	depends on !DRM_MSM
+	select AUTO_KPROFILES
+	help
+	  Select this to enable Kprofile's automatic mode changer via mi_drm_notifier.
+	  When this option is enabled, Kprofiles will automatically switch to battery
+	  mode when device screen turns off and will switch back to previously active
+	  mode when the device wakes up.
+
 config AUTO_KPROFILES_FB
 	bool "Auto Kprofiles using fb_notifier"
 	depends on FB

--- a/main.c
+++ b/main.c
@@ -8,6 +8,8 @@
 #include <linux/moduleparam.h>
 #ifdef CONFIG_AUTO_KPROFILES_MSM_DRM
 #include <linux/msm_drm_notify.h>
+#elif defined(CONFIG_AUTO_KPROFILES_MI_DRM)
+#include <drm/drm_notifier_mi.h>
 #elif defined(CONFIG_AUTO_KPROFILES_FB)
 #include <linux/fb.h>
 #endif
@@ -17,6 +19,10 @@
 #define KP_EVENT_BLANK MSM_DRM_EVENT_BLANK
 #define KP_BLANK_POWERDOWN MSM_DRM_BLANK_POWERDOWN
 #define KP_BLANK_UNBLANK MSM_DRM_BLANK_UNBLANK
+#elif defined(CONFIG_AUTO_KPROFILES_MI_DRM)
+#define KP_EVENT_BLANK MI_DRM_EVENT_BLANK
+#define KP_BLANK_POWERDOWN MI_DRM_BLANK_POWERDOWN
+#define KP_BLANK_UNBLANK MI_DRM_BLANK_UNBLANK
 #elif defined(CONFIG_AUTO_KPROFILES_FB)
 #define KP_EVENT_BLANK FB_EVENT_BLANK
 #define KP_BLANK_POWERDOWN FB_BLANK_POWERDOWN
@@ -126,6 +132,8 @@ static inline int kp_notifier_callback(struct notifier_block *self,
 {
 #ifdef CONFIG_AUTO_KPROFILES_MSM_DRM
 	struct msm_drm_notifier *evdata = data;
+#elif defined(CONFIG_AUTO_KPROFILES_MI_DRM)
+	struct mi_drm_notifier *evdata = data;
 #elif defined(CONFIG_AUTO_KPROFILES_FB)
 	struct fb_event *evdata = data;
 #endif
@@ -166,6 +174,8 @@ static int kprofiles_register_notifier(void)
 
 #ifdef CONFIG_AUTO_KPROFILES_MSM_DRM
 	ret = msm_drm_register_client(&kp_notifier_block);
+#elif defined(CONFIG_AUTO_KPROFILES_MI_DRM)
+	ret = mi_drm_register_client(&kp_notifier_block);
 #elif defined(CONFIG_AUTO_KPROFILES_FB)
 	ret = fb_register_client(&kp_notifier_block);
 #endif
@@ -177,6 +187,8 @@ static void kprofiles_unregister_notifier(void)
 {
 #ifdef CONFIG_AUTO_KPROFILES_MSM_DRM
 	msm_drm_unregister_client(&kp_notifier_block);
+#elif defined(CONFIG_AUTO_KPROFILES_MI_DRM)
+	mi_drm_unregister_client(&kp_notifier_block);
 #elif defined(CONFIG_AUTO_KPROFILES_FB)
 	fb_unregister_client(&kp_notifier_block);
 #endif


### PR DESCRIPTION
Newer Xiaomi devices utilize their own MI DRM notifier instead of MSM DRM or FB notifier. So, they need their own custom functions for auto kprofiles to work which resemble the bits of MSM_DRM. Hence, add support for it.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>