### PR TITLE
kp: Make kp_mode an unsigned int type variable

### DIFF
--- a/main.c
+++ b/main.c
@@ -38,7 +38,7 @@ static bool screen_on = true;
 static bool auto_kprofiles __read_mostly = true;
 module_param(auto_kprofiles, bool, 0664);
 
-static int kp_mode = CONFIG_DEFAULT_KP_MODE;
+static unsigned int kp_mode = CONFIG_DEFAULT_KP_MODE;
 module_param(kp_mode, int, 0664);
 
 DEFINE_MUTEX(kplock);


### PR DESCRIPTION
kp_mode's range is 0 - 3, means it only accepts positive values and can never be negative. Kprofiles also have a check to fallback to 0 if kp_mode exceeds 3 but doesn't do it for the opposite. Therefore, make kp_mode an unsigned int type variable to ignore negative values.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>