### PR TITLE
kp: Do not mark kp_notifier_callback() as an inline function

### DIFF
--- a/main.c
+++ b/main.c
@@ -127,8 +127,8 @@ int kp_active_mode(void)
 EXPORT_SYMBOL(kp_active_mode);
 
 #ifdef CONFIG_AUTO_KPROFILES
-static inline int kp_notifier_callback(struct notifier_block *self,
-				       unsigned long event, void *data)
+static int kp_notifier_callback(struct notifier_block *self,
+				unsigned long event, void *data)
 {
 #ifdef CONFIG_AUTO_KPROFILES_MSM_DRM
 	struct msm_drm_notifier *evdata = data;


### PR DESCRIPTION
An inline function is one for which the compiler copies the code from the function definition directly into the code of the calling function rather than creating a separate set of instructions in memory. This is mostly done for small computations, means a function having less codes so that we can ignore its overhead and perform faster execution.

Here, kp_notifier_callback() is by no means a small function definition. The compiler will disregard the inline function hint and optimize it. Therefore, marking the function inline is pointless and only becomes a burden for the compiler to recognize the function's body types and thereafter optimize it. Remove the inline specifier.

This reverts commit f80bb0450c69edad5d982a7de8a6c73bbd67b23b.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>