### PR TITLE
kp: Make (kp_mode > 3) statement as unlikely

### DIFF
--- a/main.c
+++ b/main.c
@@ -116,7 +116,7 @@ int kp_active_mode(void)
 	if (kp_override)
 		return kp_override_mode;
 
-	if (kp_mode > 3) {
+	if (unlikely(kp_mode > 3)) {
 		kp_mode = 0;
 		pr_info("Invalid value passed, falling back to level 0\n");
 	}


### PR DESCRIPTION
Since kp_mode will not be wrong value frequently, it makes sense to keep condition as unlikely.

Signed-off-by: Volodymyr Vasiutyk <volodymyr.vasiutyk@gmail.com>