### PR TITLE
Kprofiles: Remove AUTO_PROFILES_NONE

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -32,7 +32,8 @@ config AUTO_KPROFILES
 
 choice
 	prompt "Auto Kprofiles support"
-	default AUTO_KPROFILES_NONE
+	default AUTO_KPROFILES_MSM_DRM
+	depends on AUTO_KPROFILES
 	help
 	  This option toggles the automated mode changer in Kprofile. When enabled,
 	  Kprofiles will utilise the notifier API(s) to transition between presently
@@ -44,7 +45,6 @@ choice
 config AUTO_KPROFILES_MSM_DRM
 	bool "Auto Kprofiles using msm_drm_notifier"
 	depends on DRM_MSM
-	select AUTO_KPROFILES
 	help
 	  Select this to enable Kprofile's automatic mode changer via msm_drm_notifier.
 	  When this option is enabled, Kprofiles will automatically switch to battery
@@ -54,7 +54,6 @@ config AUTO_KPROFILES_MSM_DRM
 config AUTO_KPROFILES_MI_DRM
 	bool "Auto Kprofiles using mi_drm_notifier"
 	depends on !DRM_MSM
-	select AUTO_KPROFILES
 	help
 	  Select this to enable Kprofile's automatic mode changer via mi_drm_notifier.
 	  When this option is enabled, Kprofiles will automatically switch to battery
@@ -64,17 +63,11 @@ config AUTO_KPROFILES_MI_DRM
 config AUTO_KPROFILES_FB
 	bool "Auto Kprofiles using fb_notifier"
 	depends on FB
-	select AUTO_KPROFILES
 	help
 	  Select this to enable Kprofile's automatic mode changer via fb_notifier.
 	  When this option is enabled, Kprofiles will automatically switch to
 	  battery mode when device screen turns off and will switch back to
 	  previously active mode when the device wakes up.
-
-config AUTO_KPROFILES_NONE
-	bool "None"
-	help
-	  Select this to build Kprofiles without auto Kprofiles.
 
 endchoice
 


### PR DESCRIPTION
The current configuration of kprofiles allows users to build with auto kprofiles check but without any notifier. Auto kprofiles was supposed to be working with notifier to help save power but, auto kprofiles none breaks this moto entirely so, remove it.