### PR TITLE
kp: Refactor the display notifier callback

### DIFF
--- a/main.c
+++ b/main.c
@@ -150,27 +150,27 @@ static inline int kp_notifier_callback(struct notifier_block *self,
 				       unsigned long event, void *data)
 {
 	struct kprofiles_events *evdata = data;
-	int *blank;
+	unsigned int blank;
 
-	if (event != KP_EVENT_BLANK
-#ifdef CONFIG_AUTO_KPROFILES_MSM_DRM
-	    || !evdata || !evdata->data || evdata->id != MSM_DRM_PRIMARY_DISPLAY
-#endif
-	)
-		return NOTIFY_OK;
+	if (event != KP_EVENT_BLANK)
+		return 0;
 
-	blank = evdata->data;
-	switch (*blank) {
-	case KP_BLANK_POWERDOWN:
-		if (!screen_on)
+	if (evdata && evdata->data && event == KP_EVENT_BLANK) {
+		blank = *(int *)(evdata->data);
+		switch (blank) {
+		case KP_BLANK_POWERDOWN:
+			if (!screen_on)
+				break;
+			screen_on = false;
 			break;
-		screen_on = false;
-		break;
-	case KP_BLANK_UNBLANK:
-		if (screen_on)
+		case KP_BLANK_UNBLANK:
+			if (screen_on)
+				break;
+			screen_on = true;
 			break;
-		screen_on = true;
-		break;
+		default:
+			break;
+		}
 	}
 
 	return NOTIFY_OK;


### PR DESCRIPTION
* To bail out, we are supposed to return 0 but here it was returning NOTIFY_OK which means that notification has been processed correctly which is not true at all. We are supposed to only return NOTIFY_OK after we have finished checking our display state. Fix the broken bail out logic.

* While at it, make the event blank check global since framebuffer also needs to check it. It should not be only for DRM notifier. This is also to be noted that NOTIFY_OK needs to be returned at the end of the function underneath the conditional check, not 0.

* Provide a fallback for the switch statement.

* Cast `blank` to a pointer to an int and dereference it to evdata->data and thus simplify the usage of blank. `blank` should be non-negative.