### PR TITLE
kprofiles: Enable auto kprofiles for QGKI kernels

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -43,7 +43,7 @@ choice
 
 config AUTO_KPROFILES_MSM_DRM
 	bool "Auto Kprofiles using msm_drm_notifier"
-	depends on DRM_MSM
+	depends on DRM_MSM || QGKI
 	select AUTO_KPROFILES
 	help
 	  Select this to enable Kprofile's automatic mode changer via msm_drm_notifier.


### PR DESCRIPTION
*In QGKI kernels, `CONFIG_DRM_MSM=y` is exported from techpack/display/config/{board}disp.conf at build time rather than being enabled via defconfig as the display stack is now out of tree i.e. techpack/display. Thus the legacy way of checking if DRM_MSM is enabled or not does not work.
*Xiaomi also uses `DRM_MSM` instead of `MI_DRM_NOTIFIER`, which they used to in older kernel versions, which lets this config be enabled on Xiaomi devices too requiring no adaptation whatsoever.

Test: Enable `CONFIG_AUTO_KPROFILES_MSM_DRM` and build kernel, boot and check for the node.