### PR TITLE
Revert "kp: Kconfig: Check if msm display drivers exist in techpack"

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -43,7 +43,7 @@ choice
 
 config AUTO_KPROFILES_MSM_DRM
 	bool "Auto Kprofiles using msm_drm_notifier"
-	depends on DRM_MSM || $(shell test -d techpack/display)
+	depends on DRM_MSM
 	select AUTO_KPROFILES
 	help
 	  Select this to enable Kprofile's automatic mode changer via msm_drm_notifier.


### PR DESCRIPTION
Shell usage in Kconfig is not supported on older kernels. We need to come up with a better idea for this techpack/display availability check. Drop the unsupported dependency for now to fix the following compilation error:

$ make -j$(nproc --all) ARCH=arm64 vendor/wayne-oss-perf_defconfig O=out LLVM=1 LLVM_IAS=1 CROSS_COMPILE=aarch64-linux-gnu- "drivers/misc/kprofiles/main.o"

  GEN     ./Makefile
drivers/misc/kprofiles/Kconfig:47: syntax error
drivers/misc/kprofiles/Kconfig:46: invalid option
make[3]: *** [../scripts/kconfig/Makefile:104: vendor/wayne-oss-perf_defconfig] Error 1
make[2]: *** [../Makefile:565: vendor/wayne-oss-perf_defconfig] Error 2
make[1]: *** [/home/tashar/Atom-X-Devs-Scarlet/Makefile:293: __build_one_by_one] Error 2
make: *** [Makefile:153: sub-make] Error 2

This reverts commit 7a1baec7f3bbc729cdbc0a07c05135958dd47b37.