### PR TITLE
kp: Do not cover a bail out under mutex lock

### DIFF
--- a/main.c
+++ b/main.c
@@ -111,12 +111,12 @@ void kp_set_mode_rollback(unsigned int level, unsigned int duration_ms)
 		return;
 	}
 
-	mutex_lock(&kp_set_mode_rb_lock);
 	if (unlikely(level > 3)) {
 		kp_err("Invalid mode requested, skipping mode change.\n");
 		return;
 	}
 
+	mutex_lock(&kp_set_mode_rb_lock);
 	kp_override_mode = level;
 	kp_override = true;
 	kp_trigger_mode_change_event();


### PR DESCRIPTION
It is completely pointless to use a mutex lock for a condition that is going to stop the function aka bail out if succeeds and print a debug log. This doesn't need a separated thread to run on. So, don't do it.